### PR TITLE
Make cube install Python 3 compatible.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,11 @@ from astropy_helpers.sphinx.conf import *
 
 # Get configuration information from setup.cfg
 from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
 from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 

--- a/sunpycube/spectra/spectrogram.py
+++ b/sunpycube/spectra/spectrogram.py
@@ -12,7 +12,6 @@ from __future__ import unicode_literals
 import datetime
 
 from random import randint
-from itertools import izip
 from copy import copy
 from math import floor
 
@@ -722,7 +721,7 @@ class Spectrogram(Parent):
             freq_axis[0] >= frequency >= self_freq_axis[-1]
         """
         lfreq, lvalue = None, None
-        for freq, value in izip(self.freq_axis, self.data[:, :]):
+        for freq, value in zip(self.freq_axis, self.data[:, :]):
             if freq < frequency:
                 break
             lfreq, lvalue = freq, value
@@ -764,7 +763,7 @@ class Spectrogram(Parent):
         fillto = np.abs(fillto)
         fillfrom = np.abs(fillfrom)
 
-        for row, from_, to_ in izip(self, fillfrom, fillto):
+        for row, from_, to_ in zip(self, fillfrom, fillto):
             new[from_: to_] = row
 
         vrs = self._get_params()
@@ -997,7 +996,7 @@ class LinearTimeSpectrogram(Spectrogram):
         # Amount of pixels left out due to non-linearity. Needs to be
         # considered for correct time axes.
         sd = 0
-        for x, elem in izip(xs, specs):
+        for x, elem in zip(xs, specs):
             diff = x - elem.shape[1]
             e_time_axis = elem.time_axis
 


### PR DESCRIPTION
Some minor changes to allow ```python setup.py install``` to work in Python 3.5