### PR TITLE
adding David's #9 changes and making changes in test using the shape

### DIFF
--- a/sunpycube/cube/tests/test_cubesequence.py
+++ b/sunpycube/cube/tests/test_cubesequence.py
@@ -54,10 +54,10 @@ def test_slice_first_index_sequence(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    (seq[0:1].len, 1),
-    (seq[1:3].len, 2),
-    (seq[0:2].len, 2),
-    (seq[0:].len, 4),
+    (seq[0:1].shape[0], 1),
+    (seq[1:3].shape[0], 2),
+    (seq[0:2].shape[0], 2),
+    (seq[0:].shape[0], 4),
 ])
 def test_slice_first_index_sequence(test_input, expected):
     assert test_input == expected

--- a/sunpycube/spectra/spectrogram.py
+++ b/sunpycube/spectra/spectrogram.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 import datetime
 
 from random import randint
+from sunpy.extern.six.moves import zip
 from copy import copy
 from math import floor
 

--- a/sunpycube/spectra/tests/test_spectrogram.py
+++ b/sunpycube/spectra/tests/test_spectrogram.py
@@ -108,8 +108,8 @@ def test_slice_time_axis():
     assert new.shape == (200, 3600 - 59 - 1)
     assert new.t_init == 59
     assert np.array_equal(new.time_axis,
-        np.linspace(0, 3600 - 60 - 1, 3600 - 59 - 1)
-    )
+                          np.linspace(0, 3600 - 60 - 1, 3600 - 59 - 1)
+                          )
     assert new.start == datetime(2010, 10, 10, 0, 0, 59)
     assert np.array_equal(new.data, rnd[:, 59:3599])
 
@@ -476,21 +476,21 @@ def test_join_nonlinear():
 def test_auto_t_init():
     image = np.random.rand(200, 3600)
     assert Spectrogram(image,
-        np.linspace(0, image.shape[1] - 1, image.shape[1]),
-        np.linspace(0, image.shape[0] - 1, image.shape[0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30)
-    ).t_init == 900
+                       np.linspace(0, image.shape[1] - 1, image.shape[1]),
+                       np.linspace(0, image.shape[0] - 1, image.shape[0]),
+                       datetime(2010, 1, 1, 0, 15),
+                       datetime(2010, 1, 1, 0, 30)
+                       ).t_init == 900
 
 
 def test_rescale():
     image = np.random.rand(200, 3600) * 43
     spec = Spectrogram(image,
-        np.linspace(0, image.shape[1] - 1, image.shape[1]),
-        np.linspace(0, image.shape[0] - 1, image.shape[0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30)
-    )
+                       np.linspace(0, image.shape[1] - 1, image.shape[1]),
+                       np.linspace(0, image.shape[0] - 1, image.shape[0]),
+                       datetime(2010, 1, 1, 0, 15),
+                       datetime(2010, 1, 1, 0, 30)
+                       )
 
     nspec = spec.rescale()
 
@@ -502,11 +502,11 @@ def test_rescale():
 def test_rescale_error():
     image = np.zeros((200, 3600))
     spec = Spectrogram(image,
-        np.linspace(0, image.shape[1] - 1, image.shape[1]),
-        np.linspace(0, image.shape[0] - 1, image.shape[0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30)
-    )
+                       np.linspace(0, image.shape[1] - 1, image.shape[1]),
+                       np.linspace(0, image.shape[0] - 1, image.shape[0]),
+                       datetime(2010, 1, 1, 0, 15),
+                       datetime(2010, 1, 1, 0, 30)
+                       )
 
     with pytest.raises(ValueError) as excinfo:
         spec.rescale(0, 1)
@@ -519,11 +519,11 @@ def test_rescale_error():
 def test_rescale_error2():
     image = np.random.rand(200, 3600) * 43
     spec = Spectrogram(image,
-        np.linspace(0, image.shape[1] - 1, image.shape[1]),
-        np.linspace(0, image.shape[0] - 1, image.shape[0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30)
-    )
+                       np.linspace(0, image.shape[1] - 1, image.shape[1]),
+                       np.linspace(0, image.shape[0] - 1, image.shape[0]),
+                       datetime(2010, 1, 1, 0, 15),
+                       datetime(2010, 1, 1, 0, 30)
+                       )
 
     with pytest.raises(ValueError) as excinfo:
         spec.rescale(1, 1)
@@ -556,22 +556,22 @@ def test_upsample():
 def test_combine_freqs():
     image = np.random.rand(5, 3600)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, image.shape[1] - 1, image.shape[1]),
-        np.array([8, 6, 4, 2, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        0.25
-    )
+                                 np.linspace(0, image.shape[1] - 1, image.shape[1]),
+                                 np.array([8, 6, 4, 2, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 0.25
+                                 )
     image = np.random.rand(5, 3600)
     spec2 = LinearTimeSpectrogram(image,
-        np.linspace(0, image.shape[1] - 1, image.shape[1]),
-        np.array([9, 7, 5, 3, 1]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        0.25
-    )
+                                  np.linspace(0, image.shape[1] - 1, image.shape[1]),
+                                  np.array([9, 7, 5, 3, 1]),
+                                  datetime(2010, 1, 1, 0, 15),
+                                  datetime(2010, 1, 1, 0, 30),
+                                  900,
+                                  0.25
+                                  )
     comb = LinearTimeSpectrogram.combine_frequencies([spec, spec2])
     stuff = [spec, spec2]
 
@@ -586,22 +586,22 @@ def test_combine_freqs():
 def test_join_diff_freq():
     image = np.random.rand(5, 3600)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
-        np.array([8, 6, 4, 2, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        0.25
-    )
+                                 np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([8, 6, 4, 2, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 0.25
+                                 )
     image = np.random.rand(5, 3600)
     spec2 = LinearTimeSpectrogram(image,
-        np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
-        np.array([9, 7, 5, 3, 1]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        1800,
-        0.25
-    )
+                                  np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
+                                  np.array([9, 7, 5, 3, 1]),
+                                  datetime(2010, 1, 1, 0, 15),
+                                  datetime(2010, 1, 1, 0, 30),
+                                  1800,
+                                  0.25
+                                  )
 
     with pytest.raises(ValueError) as excinfo:
         LinearTimeSpectrogram.join_many([spec, spec2])
@@ -611,22 +611,22 @@ def test_join_diff_freq():
 def test_intersect_time():
     image = np.random.rand(5, 3600)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
-        np.array([8, 6, 4, 2, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        0.25
-    )
+                                 np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([8, 6, 4, 2, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 0.25
+                                 )
     image = np.random.rand(5, 3600)
     spec2 = LinearTimeSpectrogram(image,
-        np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
-        np.array([9, 7, 5, 3, 1]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        901,
-        0.25
-    )
+                                  np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
+                                  np.array([9, 7, 5, 3, 1]),
+                                  datetime(2010, 1, 1, 0, 15),
+                                  datetime(2010, 1, 1, 0, 30),
+                                  901,
+                                  0.25
+                                  )
 
     one, other = LinearTimeSpectrogram.intersect_time(
         [spec, spec2]
@@ -642,16 +642,17 @@ def test_intersect_time():
     assert is_linear(one.time_axis)
     assert is_linear(other.time_axis)
 
+
 def test_check_linearity():
     image = np.random.rand(5, 3600)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
-        np.array([8, 6, 4, 2, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        0.25
-    )
+                                 np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([8, 6, 4, 2, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 0.25
+                                 )
     assert spec.check_linearity()
     spec.time_axis[1] += 0.1
     assert not spec.check_linearity()
@@ -666,26 +667,26 @@ def test_flatten():
     flat = np.arange(5 * 3600)
     image = flat.reshape(5, 3600)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
-        np.array([8, 6, 4, 2, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        0.25
-    )
+                                 np.linspace(0, 0.25 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([8, 6, 4, 2, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 0.25
+                                 )
     assert np.array_equal(flat, spec.data.flatten())
 
 
 def test_in_interval():
     image = np.random.rand(5, 900)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
-        np.array([8, 6, 4, 2, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        1
-    )
+                                 np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([8, 6, 4, 2, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 1
+                                 )
 
     assert np.array_equal(spec.in_interval("00:15", "00:30").data, spec.data)
 
@@ -693,13 +694,13 @@ def test_in_interval():
 def test_in_interval2():
     image = np.random.rand(5, 900)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
-        np.array([8, 6, 4, 2, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        1
-    )
+                                 np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([8, 6, 4, 2, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 1
+                                 )
 
     assert np.array_equal(
         spec.in_interval("2010-01-01T00:15:00", "00:30").data, spec.data
@@ -709,13 +710,13 @@ def test_in_interval2():
 def test_linearize():
     image = np.random.rand(5, 900)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
-        np.array([20, 10, 5, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        1
-    )
+                                 np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([20, 10, 5, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 1
+                                 )
     # 0   1   2   3   4   5  6  7  8
     # -------- ----------- ----- ---
     # 20 17.5 15 12.5 10 7.5 5 2.5 0
@@ -737,13 +738,13 @@ def test_linearize():
 def test_linear_view():
     image = np.random.rand(5, 900)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
-        np.array([20, 10, 5, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        1
-    )
+                                 np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([20, 10, 5, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 1
+                                 )
 
     linear = _LinearView(spec)
     # assert ((linear.freq_axis[:-1] - linear.freq_axis[1:]) == 2.5).all()
@@ -762,13 +763,13 @@ def test_linear_view():
 def test_linear_view_indexerror():
     image = np.random.rand(5, 900)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
-        np.array([20, 10, 5, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        1
-    )
+                                 np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([20, 10, 5, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 1
+                                 )
 
     linear = _LinearView(spec)
     # assert ((linear.freq_axis[:-1] - linear.freq_axis[1:]) == 2.5).all()
@@ -779,13 +780,13 @@ def test_linear_view_indexerror():
 def test_linear_view_negative():
     image = np.random.rand(5, 900)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
-        np.array([20, 10, 5, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        1
-    )
+                                 np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([20, 10, 5, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 1
+                                 )
 
     linear = _LinearView(spec)
     # assert ((linear.freq_axis[:-1] - linear.freq_axis[1:]) == 2.5).all()
@@ -796,13 +797,13 @@ def test_linear_view_negative():
 def test_linear_view_freqs():
     image = np.random.rand(5, 900)
     spec = LinearTimeSpectrogram(image,
-        np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
-        np.array([20, 10, 5, 0]),
-        datetime(2010, 1, 1, 0, 15),
-        datetime(2010, 1, 1, 0, 30),
-        900,
-        1
-    )
+                                 np.linspace(0, 1 * (image.shape[1] - 1), image.shape[1]),
+                                 np.array([20, 10, 5, 0]),
+                                 datetime(2010, 1, 1, 0, 15),
+                                 datetime(2010, 1, 1, 0, 30),
+                                 900,
+                                 1
+                                 )
 
     linear = _LinearView(spec)
     # assert ((linear.freq_axis[:-1] - linear.freq_axis[1:]) == 2.5).all()

--- a/sunpycube/spectra/tests/test_spectrogram.py
+++ b/sunpycube/spectra/tests/test_spectrogram.py
@@ -371,7 +371,7 @@ def test_join_gap():
             [one, other], nonlinear=False, maxgap=0
         )
 
-    assert excinfo.value.message == "Too large gap."
+    assert excinfo.value.args[0] == "Too large gap."
 
 
 def test_join_with_gap():
@@ -432,7 +432,7 @@ def test_join_with_gap_fill():
 
     assert np.array_equal(z.data[:, :3600], one.data)
 
-    print type(z.data)
+    print(type(z.data))
 
     # Second data to unpack masked array
     assert np.isnan(z.data.data[:, 3600:3602]).all()
@@ -511,7 +511,7 @@ def test_rescale_error():
     with pytest.raises(ValueError) as excinfo:
         spec.rescale(0, 1)
     assert (
-        excinfo.value.message ==
+        excinfo.value.args[0] ==
         "Spectrogram needs to contain distinct values."
     )
 
@@ -527,7 +527,7 @@ def test_rescale_error2():
 
     with pytest.raises(ValueError) as excinfo:
         spec.rescale(1, 1)
-    assert excinfo.value.message == "Maximum and minimum must be different."
+    assert excinfo.value.args[0] == "Maximum and minimum must be different."
 
 
 def test_resample():
@@ -577,7 +577,7 @@ def test_combine_freqs():
 
     # print comb
 
-    for freq in xrange(10):
+    for freq in range(10):
         assert np.array_equal(
             comb[9 - freq, :], stuff[freq % 2][4 - freq // 2, :]
         )
@@ -605,7 +605,7 @@ def test_join_diff_freq():
 
     with pytest.raises(ValueError) as excinfo:
         LinearTimeSpectrogram.join_many([spec, spec2])
-    assert excinfo.value.message == "Frequency channels do not match."
+    assert excinfo.value.args[0] == "Frequency channels do not match."
 
 
 def test_intersect_time():

--- a/sunpycube/wcs_util.py
+++ b/sunpycube/wcs_util.py
@@ -20,8 +20,6 @@ class WCS(wcs.WCS):
             header = WCS._augment(header, naxis)
             if naxis is not None:
                 naxis = naxis + 1
-        else:
-            self.was_augmented = False
         wcs.WCS.__init__(self, header=header, naxis=naxis, **kwargs)
 
     @classmethod


### PR DESCRIPTION
made changes in the test using the shape. And adding David's stuff that he forgot to push
```python
err.message gives DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
```
and

```python
self.was_augmented = WCS._needs_augmenting(header)
if self.was_augmented:
    ......rest..of......
    ......the..code..
```
as this seems more correct this way, less lines. (:P)
