### PR TITLE
Create Xarray-like coords dictionary attribute

### DIFF
--- a/sunpycube/cube/NDCube.py
+++ b/sunpycube/cube/NDCube.py
@@ -61,7 +61,7 @@ class NDCube(astropy.nddata.NDData):
         Note however that it is not always possible to save the input as reference. Default is False.
     """
 
-    def __init__(self, data, wcs, uncertainty=None, mask=None, meta=None,
+    def __init__(self, data, uncertainty=None, mask=None, wcs=None, meta=None,
                  unit=None, coords=None, copy=False, missing_axis=None, **kwargs):
         if missing_axis is None:
             self.missing_axis = [False]*wcs.naxis


### PR DESCRIPTION
This PR creates an Xarray-like coords dictionary attribute on ```NDCube```.  This attribute allows coordinates not contained within the WCS object to be associated with data axes.  This PR also creates an attribute on ```NDCubeSequence```, ```common_axis_coords```, that allows the user to access the coord values for each coord associated with the common axis as single Quantities.