### PR TITLE
add config for pep8speak

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,9 @@
+pycodestyle:
+  max-line-length: 100 # Default is 79 in PEP8
+
+exclude:
+  - setup.py
+  - ez_setup.py
+  - ah_bootstrap.py
+  - astropy_helpers/
+  - docs/conf.py


### PR DESCRIPTION
So we keep the same rules than in SunPy